### PR TITLE
[CI] Don't exit pipeline before displaying AWS Batch logfiles (#801)

### DIFF
--- a/ci/jenkins/Jenkinsfile_py3-master_gpu_doc
+++ b/ci/jenkins/Jenkinsfile_py3-master_gpu_doc
@@ -64,6 +64,7 @@ core_logic: {
               // saved to S3 and retrieved on the CI server once the jobs
               // finished.
               sh """
+              set -ex
               conda activate ./conda/cpu/py3
 
               python3 ci/batch/submit-job.py --region us-east-1 --wait \
@@ -84,8 +85,15 @@ core_logic: {
               aws s3 cp s3://gluon-nlp-staging/batch/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/${stdout_file} ${stdout_file}
               cat ${stdout_file}
 
-              aws s3 cp s3://gluon-nlp-staging/batch/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/${ipynb_file} ${ipynb_file}
+              if [ \$BATCH_EXIT_CODE -ne 0 ]; then
+                echo AWS Batch Task Failed
+              else
+                aws s3api wait object-exists --bucket gluon-nlp-staging \
+                  --key batch/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/${ipynb_file}
+                aws s3 cp s3://gluon-nlp-staging/batch/${env.BRANCH_NAME}/${env.BUILD_NUMBER}/${ipynb_file} ${ipynb_file}
+              fi
 
+              set +ex
               exit \$BATCH_EXIT_CODE
               """
             }


### PR DESCRIPTION
submit-job.py returns non-zero exit status if the AWS Batch Task fails. The AWS
Batch Task fails in case of the submitted "--command" returning non-zero exit
status. So far, in case of submit-job.py failing, the logs of "--command" were
not retrieved and potential problems were hard to debug.

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
